### PR TITLE
Additional features

### DIFF
--- a/newrelic-logging/Chart.yaml
+++ b/newrelic-logging/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to deploy Fluentd as a DaemonSet for New Relic Logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
-name: newrelic-logging-fluentd
-version: 2.2.1
+name: newrelic-logging
+version: 2.2.2
 appVersion: v2.4.0
 home: https://github.com/newrelic/fluentd-helm
 maintainers:

--- a/newrelic-logging/Chart.yaml
+++ b/newrelic-logging/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 description: A Helm chart to deploy Fluentd as a DaemonSet for New Relic Logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
-name: newrelic-logging
+name: newrelic-logging-fluentd
 version: 2.2.1
 appVersion: v2.4.0
-home: https://www.fluentd.org/
+home: https://github.com/newrelic/fluentd-helm
 maintainers:
   - name: New Relic Logging Team
     email: logging-team@newrelic.com

--- a/newrelic-logging/templates/_helpers.tpl
+++ b/newrelic-logging/templates/_helpers.tpl
@@ -68,8 +68,41 @@ Return the licenseKey
 {{- end -}}
 
 {{/*
+Return the customSecretName
+*/}}
+{{- define "newrelic.customSecretName" -}}
+{{- if .Values.global }}
+  {{- if .Values.global.customSecretName }}
+      {{- .Values.global.customSecretName -}}
+  {{- else -}}
+      {{- .Values.customSecretName | default "" -}}
+  {{- end -}}
+{{- else -}}
+    {{- .Values.customSecretName | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the customSecretKey
+*/}}
+{{- define "newrelic.customSecretKey" -}}
+{{- if .Values.global }}
+  {{- if .Values.global.customSecretKey }}
+      {{- .Values.global.customSecretKey -}}
+  {{- else -}}
+      {{- .Values.customSecretKey | default "" -}}
+  {{- end -}}
+{{- else -}}
+    {{- .Values.customSecretKey | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Returns if the template should render, it checks if the required values are set.
 */}}
 {{- define "newrelic.areValuesValid" -}}
-{{- $licenseKey := include "newrelic-logging.licenseKey" . -}}
+{{- $licenseKey := include "newrelic.licenseKey" . -}}
+{{- $customSecretName := include "newrelic.customSecretName" . -}}
+{{- $customSecretKey := include "newrelic.customSecretKey" . -}}
+{{- or $licenseKey (and $customSecretName $customSecretKey)}}
 {{- end -}}

--- a/newrelic-logging/templates/daemonset.yaml
+++ b/newrelic-logging/templates/daemonset.yaml
@@ -1,3 +1,5 @@
+{{- if (include "newrelic.areValuesValid" .) }}
+{{- $licenseKey := include "newrelic.licenseKey" . -}}
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
@@ -33,15 +35,27 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           env:
             - name: ENDPOINT
-              {{- if eq (substr 0 2 (include "newrelic.licenseKey" .)) "eu" }}
+              {{- if  $licenseKey }} 
+                {{- if eq (substr 0 2 (include "newrelic.licenseKey" .)) "eu" }}
               value: "https://log-api.eu.newrelic.com/log/v1"
+                {{- else }}
+              value: "https://log-api.newrelic.com/log/v1"
+                {{- end }}
               {{- else }}
               value: "https://log-api.newrelic.com/log/v1"
               {{- end }}
             - name: SOURCE
               value: "kubernetes"
             - name: LICENSE_KEY
-              value: {{ template "newrelic.licenseKey" . }}
+              valueFrom:
+                secretKeyRef:
+                  {{- if $licenseKey }}
+                  name: {{ template "newrelic.fullname" . }}-config
+                  key: license
+                  {{- else }}
+                  name: {{ include "newrelic.customSecretName" . }}
+                  key: {{ include "newrelic.customSecretKey" . }}
+                  {{- end }}
           volumeMounts:
             - name: fluentd-config
               mountPath: /fluentd/etc
@@ -49,6 +63,10 @@ spec:
             - name: var
               mountPath: /var
               readOnly: false
+          {{- if .Values.resources }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          {{- end }}
       volumes:
         - name: fluentd-config
           configMap:
@@ -67,4 +85,4 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
-
+{{- end }}

--- a/newrelic-logging/templates/secrete.yaml
+++ b/newrelic-logging/templates/secrete.yaml
@@ -1,0 +1,11 @@
+{{- $licenseKey := include "newrelic.licenseKey" . -}}
+{{- if $licenseKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels: {{ include "newrelic-logging.labels" . | indent 4 }}
+  name: {{ template "newrelic-logging.fullname" . }}-config
+type: Opaque
+data:
+  license: {{ $licenseKey | b64enc }}
+{{- end }}

--- a/newrelic-logging/templates/secrete.yaml
+++ b/newrelic-logging/templates/secrete.yaml
@@ -3,8 +3,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  labels: {{ include "newrelic-logging.labels" . | indent 4 }}
-  name: {{ template "newrelic-logging.fullname" . }}-config
+  labels: {{ include "newrelic.labels" . | indent 4 }}
+  name: {{ template "newrelic.fullname" . }}-config
 type: Opaque
 data:
   license: {{ $licenseKey | b64enc }}


### PR DESCRIPTION
- Enabled daemonset to configure resource limits
- License can be fetched as custom Kubernetes secret
- Fixed a bug that threw an error when license key is not set
 `Error: rendering template failed: runtime error: slice bounds out of range`